### PR TITLE
V2.8.3

### DIFF
--- a/beszel_agent_manager/agent_manager.py
+++ b/beszel_agent_manager/agent_manager.py
@@ -46,6 +46,8 @@ def _ps_escape_single(s: str) -> str:
 
 def _ps_run(command: str, timeout: int = 60) -> subprocess.CompletedProcess:
     """Run PowerShell without showing a window."""
+    # Force TLS 1.2 for older PowerShell/.NET defaults
+    command = "try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12}catch{}; " + command
     ps = _powershell_exe()
     cmd = [ps, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command]
     kwargs = {

--- a/beszel_agent_manager/constants.py
+++ b/beszel_agent_manager/constants.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 PROJECT_NAME = "BeszelAgentManager"
-APP_VERSION = "2.8.2"
+APP_VERSION = "2.8.3"
 
 # Use a single consistent service name everywhere (Windows + NSSM)
 AGENT_SERVICE_NAME = "Beszel Agent"

--- a/beszel_agent_manager/gui.py
+++ b/beszel_agent_manager/gui.py
@@ -1146,7 +1146,7 @@ class BeszelAgentManagerApp(tk.Tk):
         # App/version link (use tk.Label to avoid native ttk white background boxes)
         self.label_app_version = tk.Label(
             left,
-            text=f"{PROJECT_NAME} {APP_VERSION}",
+            text=f"{PROJECT_NAME} v{APP_VERSION}",
             bg=self._base_bg,
             fg="#2563eb",
             font=("Segoe UI", 9, "underline"),
@@ -2896,7 +2896,7 @@ class BeszelAgentManagerApp(tk.Tk):
     def _on_version_clicked(self, _event=None):
         url = (
             "https://github.com/MiranoVerhoef/BeszelAgentManager/"
-            f"releases/tag/v{APP_VERSION}"
+            f"releases/tag/{APP_VERSION}"
         )
         self._open_url(url)
 
@@ -3141,7 +3141,7 @@ class BeszelAgentManagerApp(tk.Tk):
                     start = time.perf_counter()
                     safe_url = url.replace("'", "''")
                     ps = (
-                        "Invoke-WebRequest -UseBasicParsing -Method Head "
+                        "try{[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12}catch{}; Invoke-WebRequest -UseBasicParsing -Method Head "
                         f"-Uri '{safe_url}' -TimeoutSec 5 | Out-Null"
                     )
                     creationflags = 0

--- a/file_version_info.txt
+++ b/file_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 8, 2, 0),
-    prodvers=(2, 8, 2, 0),
+    filevers=(2, 8, 3, 0),
+    prodvers=(2, 8, 3, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -17,12 +17,12 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'Verhoef'),
             StringStruct('FileDescription', 'BeszelAgentManager'),
-            StringStruct('FileVersion', '2.8.2'),
+            StringStruct('FileVersion', '2.8.3'),
             StringStruct('InternalName', 'BeszelAgentManager'),
             StringStruct('LegalCopyright', 'Copyright (C) 2025 Verhoef'),
             StringStruct('OriginalFilename', 'BeszelAgentManager.exe'),
             StringStruct('ProductName', 'BeszelAgentManager'),
-            StringStruct('ProductVersion', '2.8.2'),
+            StringStruct('ProductVersion', '2.8.3'),
           ]
         )
       ]


### PR DESCRIPTION
- Fixed bottom-left version link to open the correct GitHub release tag (removed the incorrect v prefix). #20 
- Fixed update failures on older Windows/PowerShell clients by forcing TLS 1.2 for PowerShell download requests (prevents “Could not create SSL/TLS secure channel” errors). #18 