### PR TITLE
V2.9.1 Defender consent update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vibe Coding is used.
   - Requests Administrator rights when required (service/firewall/tasks)
   - Can relocate itself to `C:\Program Files\BeszelAgentManager` for a clean install location
   - Creates a Start Menu shortcut (removes it on uninstall)
-  - Requests Windows Defender exclusion for `C:\Program Files\BeszelAgentManager`
+  - Can add a Windows Defender exclusion for `C:\Program Files\BeszelAgentManager` only after explicit user consent
   - Enforces a single running instance (with an option to close the old one)
   - Uninstall removes service, firewall rule, tasks, agent files, and Start Menu shortcut
 

--- a/beszel_agent_manager/constants.py
+++ b/beszel_agent_manager/constants.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 PROJECT_NAME = "BeszelAgentManager"
-APP_VERSION = "2.9.0"
+APP_VERSION = "2.9.1"
 
 AGENT_SERVICE_NAME = "Beszel Agent"
 AGENT_DISPLAY_NAME = "Beszel Agent"

--- a/beszel_agent_manager/defender.py
+++ b/beszel_agent_manager/defender.py
@@ -5,6 +5,10 @@ from .constants import PROJECT_NAME, PROGRAM_FILES
 from .util import run, log
 
 
+def _ps_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
 def _defender_exclusion(path: Path, add: bool) -> tuple[bool, str]:
     if os.name != "nt":
         return True, "Non-Windows platform"
@@ -16,10 +20,8 @@ def _defender_exclusion(path: Path, add: bool) -> tuple[bool, str]:
                 "powershell",
                 "-NoLogo",
                 "-NoProfile",
-                "-ExecutionPolicy",
-                "Bypass",
                 "-Command",
-                f"{cmdlet} -ExclusionPath '{str(path)}'",
+                f"{cmdlet} -ExclusionPath {_ps_single_quote(str(path))}",
             ],
             check=False,
         )
@@ -36,7 +38,12 @@ def _defender_exclusion(path: Path, add: bool) -> tuple[bool, str]:
         return False, str(exc)
 
 
-def ensure_defender_exclusion_for_manager() -> tuple[bool, str]:
+def ensure_defender_exclusion_for_manager(*, user_consented: bool = False) -> tuple[bool, str]:
+    if not user_consented:
+        msg = "Windows Defender exclusion was not added because user consent was not provided."
+        log(msg)
+        return False, msg
+
     path = Path(PROGRAM_FILES) / PROJECT_NAME
     return _defender_exclusion(path, add=True)
 

--- a/beszel_agent_manager/gui.py
+++ b/beszel_agent_manager/gui.py
@@ -2020,18 +2020,22 @@ class BeszelAgentManagerApp(tk.Tk):
         add_defender = False
         if os.name == "nt":
             msg = (
-                "BeszelAgentManager can add a Windows Defender exclusion for its own "
-                "installation folder (C:\\Program Files\\BeszelAgentManager).\n\n"
-                "This helps prevent the manager and the tools it uses from being "
-                "blocked or slowed down during agent install/update.\n\n"
-                "Do you want to add this Defender exclusion now?"
+                "Optional Windows Defender exclusion\n\n"
+                "BeszelAgentManager can add an exclusion for its own installation "
+                "folder:\n\n"
+                "C:\\Program Files\\BeszelAgentManager\n\n"
+                "Only choose Yes if you understand and accept that Windows Defender "
+                "will skip scans for this folder. This can reduce false positives "
+                "during install/update, but it also lowers scanning coverage for "
+                "anything placed there.\n\n"
+                "Add this Defender exclusion?"
             )
             add_defender = messagebox.askyesno(PROJECT_NAME, msg)
 
         def task():
             if add_defender:
                 try:
-                    ok, reason = ensure_defender_exclusion_for_manager()
+                    ok, reason = ensure_defender_exclusion_for_manager(user_consented=True)
                     if not ok:
                         msg = (
                             "BeszelAgentManager could not configure a Windows Defender "

--- a/file_version_info.txt
+++ b/file_version_info.txt
@@ -1,7 +1,7 @@
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 9, 0, 0),
-    prodvers=(2, 9, 0, 0),
+    filevers=(2, 9, 1, 0),
+    prodvers=(2, 9, 1, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -17,12 +17,12 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'Verhoef'),
             StringStruct('FileDescription', 'BeszelAgentManager'),
-            StringStruct('FileVersion', '2.9.0'),
+            StringStruct('FileVersion', '2.9.1'),
             StringStruct('InternalName', 'BeszelAgentManager'),
             StringStruct('LegalCopyright', 'Copyright (C) 2025 Verhoef'),
             StringStruct('OriginalFilename', 'BeszelAgentManager.exe'),
             StringStruct('ProductName', 'BeszelAgentManager'),
-            StringStruct('ProductVersion', '2.9.0'),
+            StringStruct('ProductVersion', '2.9.1'),
           ]
         )
       ]


### PR DESCRIPTION
### Changed

- Bumped BeszelAgentManager version metadata to `2.9.1`.
- Clarified the Windows Defender exclusion prompt so users explicitly consent and understand the tradeoff.
- Added a helper-level consent guard so Defender exclusions are not added unless the call site passes `user_consented=True`.
- Removed `-ExecutionPolicy Bypass` from the Defender exclusion helper PowerShell invocation.
- Updated README wording to state Defender exclusions are optional and user-consented.

### Notes

Installer-format packaging is intentionally left for `3.0.0`.

### Verification

- `python -m compileall beszel_agent_manager`

Compile passed. Existing warning remains in `beszel_agent_manager/scheduler.py` for an invalid escape sequence in a generated script string; unrelated to this PR.