### PR TITLE
Fix release availability check exit code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,23 @@ jobs:
           $tag = "${{ steps.version.outputs.tag }}"
 
           git fetch origin "refs/tags/$tag:refs/tags/$tag" 2>$null
-          if (git rev-parse -q --verify "refs/tags/$tag") {
+          $tagExists = $false
+          git rev-parse -q --verify "refs/tags/$tag" 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            $tagExists = $true
+          }
+          $global:LASTEXITCODE = 0
+          if ($tagExists) {
             throw "Tag '$tag' already exists. Update VERSION before publishing a new release."
           }
+
+          $releaseExists = $false
           gh release view $tag 2>$null
           if ($LASTEXITCODE -eq 0) {
+            $releaseExists = $true
+          }
+          $global:LASTEXITCODE = 0
+          if ($releaseExists) {
             throw "Release '$tag' already exists. Update VERSION before publishing a new release."
           }
 


### PR DESCRIPTION
### Fixed

- Treat missing GitHub releases/tags as the expected successful case during the release availability check.
- Reset `$LASTEXITCODE` after `git rev-parse` and `gh release view` checks so PowerShell does not fail the step when a release is correctly absent.