### PR TITLE
V3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,11 @@ jobs:
           $version = "${{ steps.version.outputs.version }}"
           $releaseName = "${{ steps.version.outputs.release_name }}"
           if ([string]::IsNullOrWhiteSpace($env:RELEASE_NOTES_INPUT)) {
-            $releaseName | Out-File -FilePath RELEASE_NOTES.generated.md -Encoding utf8
+            if (Test-Path -Path RELEASE_NOTES.md) {
+              Get-Content -Path RELEASE_NOTES.md -Raw | Out-File -FilePath RELEASE_NOTES.generated.md -Encoding utf8
+            } else {
+              $releaseName | Out-File -FilePath RELEASE_NOTES.generated.md -Encoding utf8
+            }
           } else {
             $env:RELEASE_NOTES_INPUT | Out-File -FilePath RELEASE_NOTES.generated.md -Encoding utf8
           }

--- a/RELEASE_CHANNEL
+++ b/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-rc7
+stable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,53 @@
+# BeszelAgentManager v3.0.0
+
+This is the first installer-based release of BeszelAgentManager. Version 3.0.0 moves away from the old portable executable flow and gives the manager a cleaner, more reliable Windows installation experience.
+
+## Highlights
+
+- New Windows installer: `BeszelAgentManagerSetup.exe`
+- New install layout under `C:\Program Files\BeszelAgentManager`
+- Bundled NSSM installed at `C:\Program Files\BeszelAgentManager\nssm.exe`
+- Cleaner migration from older standalone installs
+- Optional Start Menu and Desktop shortcuts during setup
+- Improved update flow for future manager releases
+- Better handling for Windows Defender exclusions, permissions, services, and uninstall cleanup
+
+## Installer and Migration
+
+- Installs app files under `C:\Program Files\BeszelAgentManager\app`
+- Keeps NSSM at the install root for simpler service paths
+- Detects old root-layout installs in `C:\Program Files\BeszelAgentManager`
+- Offers a checked migration option when an old layout is found
+- Stops old running manager processes before cleanup
+- Migrates old autostart entries to the new installed executable
+- Removes old flat Start Menu shortcuts and creates the new installer-managed shortcut
+- Repairs permissions on an existing `C:\Program Files\Beszel-Agent` folder during migration
+
+## Service Improvements
+
+- Uses the bundled NSSM by default instead of relying on Chocolatey or external downloads
+- Recreates old services that pointed to an old NSSM path
+- Handles stale Windows service deletion by checking the service PID and killing the stale process when needed
+- Removes unsupported NSSM settings that caused service setup failures
+- Cleans up service error output so messages are easier to read
+
+## Updating
+
+- Manager updates now use the installer-based flow
+- Release assets are expected to be named `BeszelAgentManagerSetup.exe`
+- The app validates downloaded installers before running them
+- Prerelease update checks can be enabled from the manager settings
+
+## Fixes and Polish
+
+- Fixed first-run permissions on clean Windows installs
+- Fixed normal-user startup after setup
+- Fixed GUI and installer icon handling
+- Improved uninstall cleanup for Program Files and ProgramData
+- Reduced noisy scheduled-task logs
+- Preserved edited settings before admin relaunch
+- Improved support bundle diagnostics
+
+## Notes
+
+If you are upgrading from an older standalone version, run the installer normally. The setup will detect the old layout and offer the migration cleanup option automatically.


### PR DESCRIPTION
### Release

- Set `RELEASE_CHANNEL=stable`, so the workflow publishes the official `V3.0.0` release instead of an RC prerelease.
- Added friendly `RELEASE_NOTES.md` for the GitHub release body.
- Updated the release workflow to use `RELEASE_NOTES.md` automatically when no manual release notes input is provided.

### Release Notes Summary

- First installer-based release of BeszelAgentManager.
- New install layout under `C:\Program Files\BeszelAgentManager`.
- Bundled NSSM at `C:\Program Files\BeszelAgentManager\nssm.exe`.
- Migration from older standalone installs.
- Installer cleanup for old Program Files root layouts.
- Improved manager update flow, permissions, service handling, uninstall cleanup, and diagnostics.

### Verification

- `git diff --check`