### PR TITLE
4.0.4 RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Last-run and next-due state is persisted in `background-runtime-state.json`. Ena
 
 Agent assets are selected only from the official Beszel GitHub repository.
 
-Manager updates accept only a selected release tag from the hardcoded project repository. Bundled installations keep using the Bundled installer and Lite installations keep using the Lite installer. The selected edition appears beside the manager version in the UI. The background service downloads the exact installer and `SHA256SUMS.txt` assets into a restricted staging directory, verifies the checksum, rejects invalid paths and reparse points, and launches Inno Setup silently after the UI exits. Authenticode is also required when a release is signed.
+Manager updates accept only a selected release tag from the hardcoded project repository. Standard installations keep using the standard installer and Lite installations keep using the Lite installer. Lite appears beside the manager version in the UI; the standard edition remains plain `BeszelAgentManager`. The background service downloads the exact installer and `SHA256SUMS.txt` assets into a restricted staging directory, verifies the checksum, rejects invalid paths and reparse points, and launches Inno Setup silently after the UI exits. Authenticode is also required when a release is signed.
 
 ## Migration from 3.1.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 - Adds a Bundled installer containing .NET 10 for the easiest setup.
 - Adds a smaller Lite installer for systems with Microsoft .NET 10 Desktop Runtime x64 already installed.
 - Lite setup detects a missing runtime, offers to open the official Microsoft download page, and waits for the runtime before installation.
-- Manager updates preserve the installed Bundled or Lite edition and display that edition beside the version number.
+- Manager updates preserve the installed standard or Lite edition; only Lite adds an edition label beside the version number.
 - Release checksums cover both fixed, allowlisted installer filenames.
 
 ## Update reliability

--- a/installer/BeszelAgentManager.iss
+++ b/installer/BeszelAgentManager.iss
@@ -11,7 +11,7 @@
 #define OutputSuffix "-Lite"
 #else
 #define RuntimeVariantId "bundled"
-#define RuntimeVariantSuffix " Bundled"
+#define RuntimeVariantSuffix ""
 #define OutputSuffix ""
 #endif
 

--- a/src/BeszelAgentManager.Helper/Program.cs
+++ b/src/BeszelAgentManager.Helper/Program.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
+using System.ComponentModel;
 using System.IO.Compression;
 using System.IO.Pipes;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Security.AccessControl;
 using System.Security.Cryptography;
@@ -1078,6 +1080,7 @@ static int EnsureBrokerPolicy()
 {
     try
     {
+        EnableRestorePrivilege();
         var path = BrokerPolicyPath();
         var dataDirectory = Path.GetDirectoryName(path)!;
         if (Directory.Exists(dataDirectory)
@@ -1126,6 +1129,42 @@ static int EnsureBrokerPolicy()
     {
         WriteBackgroundLog("ERROR", $"Could not create broker policy: {ex}");
         return 5;
+    }
+}
+
+static void EnableRestorePrivilege()
+{
+    using var identity = WindowsIdentity.GetCurrent(
+        TokenAccessLevels.AdjustPrivileges | TokenAccessLevels.Query);
+    if (!NativeMethods.LookupPrivilegeValue(null, "SeRestorePrivilege", out var privilegeId))
+    {
+        throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not find SeRestorePrivilege.");
+    }
+
+    var privileges = new TokenPrivileges
+    {
+        PrivilegeCount = 1,
+        Privileges = new LuidAndAttributes
+        {
+            Luid = privilegeId,
+            Attributes = NativeMethods.SePrivilegeEnabled,
+        },
+    };
+    if (!NativeMethods.AdjustTokenPrivileges(
+            identity.AccessToken,
+            disableAllPrivileges: false,
+            ref privileges,
+            bufferLength: 0,
+            IntPtr.Zero,
+            IntPtr.Zero))
+    {
+        throw new Win32Exception(Marshal.GetLastWin32Error(), "Could not enable SeRestorePrivilege.");
+    }
+
+    const int ErrorNotAllAssigned = 1300;
+    if (Marshal.GetLastWin32Error() == ErrorNotAllAssigned)
+    {
+        throw new Win32Exception(ErrorNotAllAssigned, "The elevated installer token does not contain SeRestorePrivilege.");
     }
 }
 
@@ -2819,6 +2858,46 @@ static async Task<(int ExitCode, string Output)> RunProcessWithTimeoutAsync(
 }
 
 internal readonly record struct AgentRelease(string Version, string DownloadUrl);
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct Luid
+{
+    public uint LowPart;
+    public int HighPart;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct LuidAndAttributes
+{
+    public Luid Luid;
+    public uint Attributes;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TokenPrivileges
+{
+    public uint PrivilegeCount;
+    public LuidAndAttributes Privileges;
+}
+
+internal static class NativeMethods
+{
+    internal const uint SePrivilegeEnabled = 0x00000002;
+
+    [DllImport("advapi32.dll", EntryPoint = "LookupPrivilegeValueW", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool LookupPrivilegeValue(string? systemName, string name, out Luid luid);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool AdjustTokenPrivileges(
+        Microsoft.Win32.SafeHandles.SafeAccessTokenHandle tokenHandle,
+        [MarshalAs(UnmanagedType.Bool)] bool disableAllPrivileges,
+        ref TokenPrivileges newState,
+        uint bufferLength,
+        IntPtr previousState,
+        IntPtr returnLength);
+}
 
 internal sealed class BrokerPolicy
 {

--- a/src/BeszelAgentManager.WinUI/MainWindow.xaml.cs
+++ b/src/BeszelAgentManager.WinUI/MainWindow.xaml.cs
@@ -68,7 +68,7 @@ public sealed partial class MainWindow : Window
             _shutdown.Dispose();
         };
 
-        VersionBadgeText.Text = $"v{AppInfo.Version} {AppInfo.RuntimeVariantDisplayName}";
+        VersionBadgeText.Text = $"v{AppInfo.Version}{AppInfo.RuntimeVariantVersionSuffix}";
         NavFrame.Navigate(typeof(ConnectionPage));
         _ = RefreshStatusAsync();
 

--- a/src/BeszelAgentManager.WinUI/Services/AppInfo.cs
+++ b/src/BeszelAgentManager.WinUI/Services/AppInfo.cs
@@ -13,7 +13,8 @@ internal static class AppInfo
     public static string RuntimeVariant => ReadRuntimeVariant();
     public static bool IsLiteRuntimeVariant =>
         string.Equals(RuntimeVariant, "lite", StringComparison.OrdinalIgnoreCase);
-    public static string RuntimeVariantDisplayName => IsLiteRuntimeVariant ? "Lite" : "Bundled";
+    public static string RuntimeVariantDisplayName => IsLiteRuntimeVariant ? "Lite" : "standard";
+    public static string RuntimeVariantVersionSuffix => IsLiteRuntimeVariant ? " Lite" : string.Empty;
     public static string InstallerAssetName => IsLiteRuntimeVariant
         ? LiteInstallerAssetName
         : BundledInstallerAssetName;


### PR DESCRIPTION
## Summary

- enable SeRestorePrivilege before assigning protected ProgramData ownership during broker setup
- fix clean Lite installs failing with background-service helper exit code 5
- keep standard installer/app naming plain BeszelAgentManager
- add the Lite suffix only to Lite installer and UI version

## Root cause

The installer ran elevated, but Windows leaves SeRestorePrivilege disabled in the administrator token. The helper attempted to set the ProgramData owner to Administrators while applying protected ACLs, causing a clean-install failure on the test machine. The fix enables the existing administrator privilege before applying ownership and DACLs; no ACLs are weakened.

## Validation

- Release solution build: passed with zero warnings/errors
- Core tests: 8 passed
- Framework-dependent Lite build: passed
- Standard and Lite Inno installers: compiled successfully
- Installer metadata verified: standard is BeszelAgentManager Installer; Lite is BeszelAgentManager Lite Installer